### PR TITLE
Update code of conduct.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,9 +1,6 @@
-# Microsoft Open Source Code of Conduct
+# Code of Conduct
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+This project has adopted the code of conduct defined by the Contributor Covenant
+to clarify expected behavior in our community.
 
-Resources:
-
-- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
-- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
-- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns
+For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).

--- a/README.md
+++ b/README.md
@@ -146,7 +146,3 @@ must follow Microsoft’s Trademark & Brand Guidelines. Use of Microsoft
 trademarks or logos in modified versions of this project must not cause
 confusion or imply Microsoft sponsorship. Any use of third-party trademarks or
 logos are subject to those third-party’s policies.
-
-# Contributing
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
* Use the .NET Foundation Code of Conduct.
* Remove references to the code of conduct.

This is following the recommendations here: https://github.com/dotnet/org-policy/blob/main/doc/PR15.md.

See also https://github.com/dotnet/org-policy-violations/issues/5602.